### PR TITLE
Fix custom share server functionality

### DIFF
--- a/ShareClient/ShareClient.swift
+++ b/ShareClient/ShareClient.swift
@@ -30,7 +30,18 @@ public enum ShareError: Error {
 public enum KnownShareServers: String {
     case US="https://share1.dexcom.com"
     case NON_US="https://shareous1.dexcom.com"
+    /*
+         To enable Loop to use a custom share server:
+            - remove the comment marker on line 44 and change the value of CUSTOM
+            - remove the comment markers on lines 34 and 35 in ShareClientUI/ShareService+UI.swift
 
+         Note: The URL in CUSTOM must start with 'https://' (NOT 'http://')
+
+         You can find installation instructions for one such custom share server at
+         https://github.com/dabear/NightscoutShareServer
+    */
+
+    // case CUSTOM="https://yourusernameshareserver.herokuapp.com"
 }
 
 // From the Dexcom Share iOS app, via @bewest and @shanselman:

--- a/ShareClient/ShareService.swift
+++ b/ShareClient/ShareService.swift
@@ -23,23 +23,6 @@ public class ShareService: ServiceAuthentication {
             url?.absoluteString
         ]
 
-        /*
-         To enable Loop to use a custom share server, change the value of customServer 
-         and remove the comment markers on line 55 and 62.
-
-         You can find installation instructions for one such custom share server at
-         https://github.com/dabear/NightscoutShareServer
-         */
-
-        /*
-        let customServer = "https://REPLACEME"
-        let customServerTitle = "Custom"
-
-        credentials[2].options?.append(
-                (title: LocalizedString(customServerTitle, comment: "Custom share server option title"),
-                value: customServer))
-        */
-
         if let username = username, let password = password, let url = url {
             isAuthorized = true
             client = ShareClient(username: username, password: password, shareServer: url.absoluteString)

--- a/ShareClientUI/ShareService+UI.swift
+++ b/ShareClientUI/ShareService+UI.swift
@@ -30,7 +30,9 @@ extension ShareService: ServiceAuthenticationUI {
                      value: KnownShareServers.US.rawValue),
                     (title: LocalizedString("Outside US", comment: "Outside US share server option title"),
                      value: KnownShareServers.NON_US.rawValue)
-
+                    // remove the comment markers on lines 34 and 35 to use a custom share server
+                    // ,(title: LocalizedString("Custom", comment: "Custom share server option title"),
+                    //  value: KnownShareServers.CUSTOM.rawValue)
                 ]
             )
         ]


### PR DESCRIPTION
Although tried and implemented before, the current implementation does not have a working solution to enable the use of a custom share server for Dexcom share.
I fixed this and added support for a custom share server. The user has to uncomment 3 lines in 2 different files and add his custom share server URL. The option "Custom" will appear in the Dexcom Share server selection in Loop.
<img src="https://user-images.githubusercontent.com/16063287/66261669-70087500-e7da-11e9-8f2f-9316ee8817b2.PNG" width="400"/>

This is needed for CGMs that cannot be directly connected via the phone and need data to be retrieved from Nightscout by using a share server that supports Nightscout (https://github.com/dabear/NightscoutShareServer).