### PR TITLE
share server change

### DIFF
--- a/ShareClient/ShareClient.swift
+++ b/ShareClient/ShareClient.swift
@@ -28,8 +28,8 @@ public enum ShareError: Error {
 
 
 public enum KnownShareServers: String {
-    case US="https://share1.dexcom.com"
-    case NON_US="https://shareous1.dexcom.com"
+    case US="https://share2.dexcom.com"
+    case NON_US="https://shareous2.dexcom.com"
 
 }
 

--- a/ShareClient/ShareService.swift
+++ b/ShareClient/ShareService.swift
@@ -88,7 +88,7 @@ public class ShareService: ServiceAuthentication {
 
 
 private let DexcomShareURL = URL(string: KnownShareServers.US.rawValue)!
-private let DexcomShareServiceLabel = "DexcomShare1"
+private let DexcomShareServiceLabel = "DexcomShare2"
 
 
 extension KeychainManager {


### PR DESCRIPTION
In light of the announcement https://www.dexcom.com/obsolescence, we should switch to a share2 to continue share support.