### PR TITLE
Fix dexcom share for non US users.

### DIFF
--- a/ShareClient/ShareClient.swift
+++ b/ShareClient/ShareClient.swift
@@ -29,7 +29,7 @@ public enum ShareError: Error {
 
 public enum KnownShareServers: String {
     case US="https://share2.dexcom.com"
-    case NON_US="https://shareous2.dexcom.com"
+    case NON_US="https://shareous1.dexcom.com"
 
 }
 


### PR DESCRIPTION
This is a fix for https://github.com/LoopKit/Loop/issues/1401

Current `dev` (and other branches) use `server = "shareous2.dexcom.com"` and it should use `server = "shareous1.dexcom.com";`. Without this fix non-US users can't use a Dexcom Share account, because Loop will give the following error:

![image](https://user-images.githubusercontent.com/6500826/102725163-e37da000-4314-11eb-9d58-0b1655fd8110.png)

This is also fixed in share2nightscout-bridge, see https://github.com/nightscout/share2nightscout-bridge/commit/ea868582d8fb6fcd3be8c6e320283cbc3549eec2


Note that Dexcom already removed `shareous2.dexcom.com`. The DNS entry gives `** server can't find shareous2.dexcom.com: NXDOMAIN`.
